### PR TITLE
Redis dependency should (at the very least) be optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "https",
     "request"
   ],
-  "dependencies": {
+  "optionalDependencies": {
     "hiredis": "0.1.x",
     "redis": "0.7.x"
   },


### PR DESCRIPTION
In the first place I am not sure redis should be a dependency at all, but if it has to be then at the very least it should be an optional one. The painful thing about the redis dependency is that it require native modules (node_gyp) which is not something you want if you can prevent it :) .
