### PR TITLE
use a utf8 buffer for the requests

### DIFF
--- a/lib/request-caching.js
+++ b/lib/request-caching.js
@@ -150,6 +150,8 @@ RequestCaching.prototype.request = function(options, callback) {
 
       var body = '';
 
+      res.setEncoding("utf8");
+
       res.on('data', function(chunk) {
         body += chunk;
       });

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "https",
     "request"
   ],
-  "dependencies": {
+  "optionalDependencies": {
     "hiredis": "0.1.x",
     "redis": "0.7.x"
   },


### PR DESCRIPTION
Hi,

thanks for this great package.
I just experienced problems when requesting utf8 documents.
Imho we should make the request buffer utf8-encoded by default.

Here's a short example of downloading an utf8-encoded file:

```
var _ = require("underscore");
var RequestCaching = require("node-request-caching");
var url = "https://raw.githubusercontent.com/bbglab/muts-needle-plot/master/src/js/dependencies/d3.js";

var rc = new RequestCaching();

rc.get(
  url, {}, 1,
  function(err, res, body) {
    console.log(_.filter(body.split("\n"), function(e, i) {
      return i > 3387 && i < 3389;
    }).join("\n"));
  });
```

this should a utf8 string with λ and φ.

```
listener.point(sλ1, φ0);
```

BTW the current version returns the non-utf8 version:

```
listener.point(s��1, φ0);
```
